### PR TITLE
nginx defaults to mime-type text/plain

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,9 +72,10 @@ services:
       - back-tier
     command: --config.file=/blackbox/config.yml
 
-  nginx_static:
+  nginx:
     image: nginx
     ports:
       - 80:80
     volumes:
       - ./nginx/html:/usr/share/nginx/html:ro
+      - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf:ro

--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -1,0 +1,33 @@
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    # default_type  application/octet-stream;
+    default_type  text/plain;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
This makes /metrics show in browser instead of being treated as
a binary and generating a download prompt in browser.