### PR TITLE
Put BlackBox Exporter targets in a file for each deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ config/*
 !config/example-target
 cloudformation/params/*
 !cloudformation/params/promcom-params-skeleton.json
+prometheus/blackbox-targets-*
+!prometheus/blackbox-targets-example.yml

--- a/config/example-target
+++ b/config/example-target
@@ -1,2 +1,3 @@
 PROMCOM_TARGET_HOST=metrics.example.com
 PROMCOM_SSH_PRIVATE_KEY="~/.ssh/promcom-example"
+PROMCOM_BLACKBOX_TARGETS="prometheus/blackbox-targets-example.yml"

--- a/prometheus/blackbox-targets-example.yml
+++ b/prometheus/blackbox-targets-example.yml
@@ -1,0 +1,3 @@
+- targets:
+  - https://www.google.com/
+  - https://www.yahoo.com/

--- a/prometheus/config.yml
+++ b/prometheus/config.yml
@@ -52,6 +52,9 @@ scrape_configs:
     static_configs:
       - targets:
         - http://localhost/
+    file_sd_configs:
+      - files:
+        - blackbox*.yml
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/script/deploy
+++ b/script/deploy
@@ -5,6 +5,7 @@ set -eu -o pipefail
 #
 # PROMCOM_TARGET_HOST=example.com
 # PROMCOM_SSH_PRIVATE_KEY="${HOME}/.ssh/example-key"
+# PROMCOM_BLACKBOX_TARGETS="blackbox-targets-exmaple.yml"
 #
 config_file="${1:-}"
 if [[ -f $config_file ]]; then
@@ -18,7 +19,10 @@ fi
 echo
 echo "# Syncing this repo with promcom ec2 instance"
 rsync -avz                                                                     \
+  --delete-excluded                                                            \
   --exclude .git                                                               \
+  --include "$PROMCOM_BLACKBOX_TARGETS"                                        \
+  --exclude 'prometheus/blackbox*'                                             \
   -e "ssh -o 'IdentitiesOnly yes' -o 'IdentityFile $PROMCOM_SSH_PRIVATE_KEY' " \
   .                                                                            \
   "ec2-user@$PROMCOM_TARGET_HOST:promcom/"
@@ -30,9 +34,9 @@ if [[ ${1:-} == '--provision' || ${1:-} == '-p' ]]; then
   ./script/promcom-ssh "$config_file" sudo promcom/script/install-docker.sh
 fi
 
-echo
-echo "# Running docker-compose pull"
-./script/promcom-ssh "$config_file" docker-compose --file promcom/docker-compose.yml pull
+# echo
+# echo "# Running docker-compose pull"
+# ./script/promcom-ssh "$config_file" docker-compose --file promcom/docker-compose.yml pull
 echo
 echo "# Running docker-compose up"
 ./script/promcom-ssh "$config_file" docker-compose --file promcom/docker-compose.yml up --detach


### PR DESCRIPTION
We want to manage multiple Prometheus deployments from this repo.
Keep a file for BlackBox targets for each deployment in prometheus/
and point to it in config/TARGET_FILE for the deployment